### PR TITLE
fixing KeyError for X-Request-Id header

### DIFF
--- a/pyghee/lib.py
+++ b/pyghee/lib.py
@@ -27,7 +27,7 @@ def get_event_info(request):
     """
     event_info = {
         'action': request.json.get('action', UNKNOWN),
-        'id': request.headers['X-Request-Id'],
+        'id': request.headers['X-Github-Delivery'],
         'signature-sha1': request.headers['X-Hub-Signature'],
         'timestamp_raw': request.headers['Timestamp'],
         'type': request.headers['X-GitHub-Event'],


### PR DESCRIPTION
fixing KeyError for non-existing X-Request-Id header; apparently X-Request-ID was renamed to X-Github-Delivery