### PR TITLE
Remove PyGithub dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Mac files
+.DS_Store
+
+# Python artifacts
+__pycache__
+
+# Application logs
+events_log
+pyghee.log

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It takes care of:
 `PyGHee` depends on a couple of Python libraries:
 
 * [Flask](https://pypi.org/project/Flask), a simple framework for building complex web applications;
+* [requests](https://pypi.org/project/requests/), a simple HTTP library that provides a CaseInsensitiveDict; 
 * [waitress](https://pypi.org/project/waitress), a production-quality pure-Python [WSGI](https://www.python.org/dev/peps/pep-3333) server;
 
 For more specific information, like required versions, see [requirements.txt](requirements.txt).
@@ -120,7 +121,7 @@ if __name__ == '__main__':
 
 To run your GitHub App:
 
-* Define an environment variables for the [GitHub app secret token](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks):
+* Define an environment variable for the [GitHub app secret token](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks):
   ```
   export GITHUB_APP_SECRET_TOKEN=...
   ```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ It takes care of:
 `PyGHee` depends on a couple of Python libraries:
 
 * [Flask](https://pypi.org/project/Flask), a simple framework for building complex web applications;
-* [PyGithub](https://pypi.org/project/PyGithub), a Python library to access the [GitHub REST API](https://docs.github.com/en/rest);
 * [waitress](https://pypi.org/project/waitress), a production-quality pure-Python [WSGI](https://www.python.org/dev/peps/pep-3333) server;
 
 For more specific information, like required versions, see [requirements.txt](requirements.txt).
 
 In addition:
-* a [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) must be available via the `$GITHUB_TOKEN` environment variable;
 * the [GitHub app secret token](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks) must be available via the `$GITHUB_APP_SECRET_TOKEN` environment variable;
 
 ## Installation
@@ -75,10 +73,10 @@ The `PyGHee` log file is named `pyghee.log` is located in the directory where th
 
 Event data is logged in JSON format in a directory named `events_log` that is located in the directory where the GitHub App is started.
 
-The logs are organised hierarchically, by *event type*, *event action*, *date* (in that order).
+The logs are organized hierarchically, by *event type*, *event action*, *date* (in that order).
 
 For each incoming event, two JSON files are created, one for:
-* the request headers including high-level information like the timestamp on which the event occured, etc.
+* the request headers including high-level information like the timestamp on which the event occurred, etc.
 * the request body including the actual event information (which depends on the event type).
 
 Here's an example of a single event that got logged: an issue commented that was created on 20 Feb 2022 at 14:23:27:
@@ -122,9 +120,8 @@ if __name__ == '__main__':
 
 To run your GitHub App:
 
-* Define environment variables for [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [GitHub app secret token](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks):
+* Define an environment variables for the [GitHub app secret token](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks):
   ```
-  export GITHUB_TOKEN=...
   export GITHUB_APP_SECRET_TOKEN=...
   ```
 

--- a/pyghee/lib.py
+++ b/pyghee/lib.py
@@ -41,7 +41,7 @@ def get_event_info(request):
         'raw_request_headers': dict(request.headers),
     })
 
-    timestamp = datetime.datetime.fromtimestamp(int(event_info['timestamp_raw'])/1000., datetime.UTC)
+    timestamp = datetime.datetime.fromtimestamp(int(event_info['timestamp_raw'])/1000., tz=datetime.UTC)
     event_info['timestamp'] = timestamp
     event_info['date'] = timestamp.isoformat().split('T')[0]
     event_info['time'] = timestamp.isoformat().split('T')[1].split('.')[0].replace(':', '-')

--- a/pyghee/lib.py
+++ b/pyghee/lib.py
@@ -9,7 +9,6 @@
 import datetime
 import flask
 import hmac
-import github
 import json
 import os
 import threading
@@ -42,7 +41,7 @@ def get_event_info(request):
         'raw_request_headers': dict(request.headers),
     })
 
-    timestamp = datetime.datetime.utcfromtimestamp(int(event_info['timestamp_raw'])/1000.)
+    timestamp = datetime.datetime.fromtimestamp(int(event_info['timestamp_raw'])/1000., datetime.UTC)
     event_info['timestamp'] = timestamp
     event_info['date'] = timestamp.isoformat().split('T')[0]
     event_info['time'] = timestamp.isoformat().split('T')[1].split('.')[0].replace(':', '-')
@@ -69,14 +68,6 @@ class PyGHee(flask.Flask):
         PyGHee constructor.
         """
         super(PyGHee, self).__init__('PyGHee', *args, **kwargs)
-
-        github_token = os.getenv('GITHUB_TOKEN')
-        if github_token is None:
-            error("GitHub token is not available via $GITHUB_TOKEN!")
-        else:
-            del os.environ['GITHUB_TOKEN']
-
-        self.gh = github.Github(github_token)
 
         # see https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks
         self.github_app_secret_token = os.getenv('GITHUB_APP_SECRET_TOKEN')
@@ -172,7 +163,7 @@ class PyGHee(flask.Flask):
                         abort_function(403)
                 else:
                     # we only know how to verify a SHA1 signature
-                    log_warning("Uknown type of signature (%s) => 501" % signature_type, log_file=log_file)
+                    log_warning("Unknown type of signature (%s) => 501" % signature_type, log_file=log_file)
                     abort_function(501)
             else:
                 log_warning("Type of signature not specified (%s) => 501" % header_signature, log_file=log_file)

--- a/pyghee/lib.py
+++ b/pyghee/lib.py
@@ -192,6 +192,9 @@ class PyGHee(flask.Flask):
                 tb_txt = ''.join(traceback.format_exception(None, err, err.__traceback__))
                 log_warning("A crash occurred!\n" + tb_txt, log_file=log_file)
 
+    @property
+    def gh(self):
+        raise Exception("The gh property and PyGithub dependency have been removed from PyGHee. To create and authenticate a github.GitHub object, follow PyGithub's documentation here: https://pygithub.readthedocs.io/en/stable/examples/Authentication.html")
 
 def create_app(klass=None):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask<3,>=2.0.3
-PyGithub<2,>=1.55
 waitress<3,>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask<3,>=2.0.3
+requests>=2.14.0
 waitress<3,>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.1.0",
     author="Kenneth Hoste",
     author_email="kenneth.hoste@ugent.be",
-    description="PyGHee (pronounced as 'piggy') is the GitHub Event Executor, a Python library to facilitate creating a GitHub App implemented in Python to process [events from GitHub",
+    description="PyGHee (pronounced as 'piggy') is the GitHub Event Executor, a Python library to facilitate creating a GitHub App implemented in Python to process events from GitHub",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/boegel/pyghee",
@@ -24,7 +24,6 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "Flask",
-        "PyGithub",
         "waitress",
    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "Flask",
+        "requests",
         "waitress",
    ],
 )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -65,7 +65,6 @@ def test_process_event(tmpdir):
     events_log_dir = os.path.join(tmpdir, 'events_log_dir')
     log_file = os.path.join(tmpdir, 'pyghee.log')
 
-    os.environ['GITHUB_TOKEN'] = 'fake_token'
     os.environ['GITHUB_APP_SECRET_TOKEN'] = 'fake_app_secret_token'
     pyghee = ExamplePyGHee()
 
@@ -121,7 +120,6 @@ def test_verify_request(tmpdir):
     """
     log_file = os.path.join(tmpdir, 'pyghee.log')
 
-    os.environ['GITHUB_TOKEN'] = 'fake_token'
     os.environ['GITHUB_APP_SECRET_TOKEN'] = TEST_SECRET_TOKEN
 
     pyghee = ExamplePyGHee()


### PR DESCRIPTION
# Summary
Remove the unused PyGithub dependency and make additional small updates.

# Changes
- Remove creation of Github instance object because it's not referenced after it's creation
- Raise an exception when attempting to access the now deprecated `gh` property
- Remove the GitHub token which was only used to create a GitHub instance object which has now been removed
- Remove PyGithub dependency now that all references to it's use are removed
- Add requests dependency which was previously installed with PyGithub
- Replace deprecated `utcfromtimestamp` in unit tests
- Add .gitignore to prevent unwanted files from making it into the code
- Correct typos to increase professionalism of code

# Impacts
1. Because the connection to PyGithub has been removed, issue #5 is no longer needed.
2. In that issue, it links to an external PR: https://github.com/EESSI/eessi-bot-software-layer/pull/2#discussion_r894903968 where it mentions that EESSI's requirement for a GitHub token comes from PyGHee's requirement. Now that this is being removed, EESSI should be reviewed to see if it's GITHUB_TOKEN requirement can also be removed.